### PR TITLE
Update Mythic.cs

### DIFF
--- a/DarkCodex/Mythic.cs
+++ b/DarkCodex/Mythic.cs
@@ -123,6 +123,7 @@ namespace DarkCodex
         {
             var smite_evil = ResourcesLibrary.TryGetBlueprint<BlueprintAbility>("7bb9eb2042e67bf489ccd1374423cdec");
             var smite_chaos = ResourcesLibrary.TryGetBlueprint<BlueprintAbility>("a4df3ed7ef5aa9148a69e8364ad359c5");
+            var mark_of_justice = ResourcesLibrary.TryGetBlueprint<BlueprintAbility>("7a4f0c48829952e47bb1fd1e4e9da83a");
             var abundant_smite = Helper.ToRef<BlueprintFeatureReference>("7e5b63faeca24474db0bfd019167dda4");
             var abundant_smitechaos = Helper.ToRef<BlueprintFeatureReference>("4cdc155e26204491ba4d193646cb4443");
 
@@ -139,6 +140,7 @@ namespace DarkCodex
 
             smite_evil.GetComponent<AbilityResourceLogic>().ResourceCostDecreasingFacts.Add(limitless.ToRef2());
             smite_chaos.GetComponent<AbilityResourceLogic>().ResourceCostDecreasingFacts.Add(limitless.ToRef2());
+            mark_of_justice.GetComponent<AbilityResourceLogic>().ResourceCostDecreasingFacts.Add(limitless.ToRef2());
 
             Helper.AddMythicTalent(limitless);
         }


### PR DESCRIPTION
Added Mark of Justice (level 11 paladin feature, uses 2 smites) to Limitless Smite. It should now also have unlimited uses.