### PR TITLE
Update Mythic.cs

### DIFF
--- a/DarkCodex/Mythic.cs
+++ b/DarkCodex/Mythic.cs
@@ -63,8 +63,14 @@ namespace DarkCodex
             if (Helper.Get("43385175fd022c546865e7b37bcc08ce") is BlueprintAbilityResource evangelist_resource
                 && Helper.Get("8ba4962b1a4b4344ba5dbcb041ab0efa") is BlueprintFeature evangelist_prereq)
             {
-                limitless.AddComponents(Helper.CreatePrerequisiteFeature(evangelist_prereq));
+                limitless.AddComponents(Helper.CreatePrerequisiteFeature(evangelist_prereq, true));
                 SetResourceDecreasing(evangelist_resource.AssetGuid, limitless);
+            }
+
+            // mod Homebrew Archetypes: Dervish of the Dawn
+            if ( Helper.Get("a077d4fe75dd0b846a1507f64bff71f8") is BlueprintFeature dervish_prereq)
+            {
+                limitless.AddComponents(Helper.CreatePrerequisiteFeature(dervish_prereq, true));
             }
 
             // same again for skald raging song
@@ -191,8 +197,9 @@ namespace DarkCodex
         {
             var bomb_resource = BlueprintGuid.Parse("1633025edc9d53f4691481b48248edd7");
             var incense_resource = BlueprintGuid.Parse("d03d97aac38e798479b81dfa9eda55c6");
-            var bomb_prereq = Helper.ToRef<BlueprintFeatureReference>("54c57ce67fa1d9044b1b3edc459e05e2"); //AlchemistBombsFeature
+            var bomb_prereq = Helper.ToRef<BlueprintFeatureReference>("c59b2f256f5a70a4d896568658315b7d"); //AlchemistBombsFeature
             var incense_prereq = Helper.ToRef<BlueprintFeatureReference>("7614401346b64a8409f7b8c367db488f"); //IncenseFogFeature
+            var incense30_prereq = Helper.ToRef<BlueprintFeatureReference>("27c7f9e491a540243a535ac9aabb8ea5"); //IncenseFog30Feature
 
             var limitless = Helper.CreateBlueprintFeature(
                 "LimitlessBombs",
@@ -202,7 +209,8 @@ namespace DarkCodex
                 icon: Helper.StealIcon("5fa0111ac60ed194db82d3110a9d0352")
                 ).SetComponents(
                 Helper.CreatePrerequisiteFeature(bomb_prereq, true),
-                Helper.CreatePrerequisiteFeature(incense_prereq, true)
+                Helper.CreatePrerequisiteFeature(incense_prereq, true),
+                Helper.CreatePrerequisiteFeature(incense30_prereq, true)
                 );
 
             SetResourceDecreasing(bomb_resource, limitless);


### PR DESCRIPTION
Hello there, thank you for the great mod. I encountered a few issues I can only assume are bugs and took the time to fix them using dnSpy. I thought I may as well share what  I came up with. The part about dervish of the dawn proved to be futile for reasons described below. I decided to keep it in to leave the decision to you.

- `limitless.AddComponents(Helper.CreatePrerequisiteFeature(evangelist_prereq, true));` was missing the true parameter which made it an AND instead of an OR. With HA installed, bards could not select the feat.

- I tried to add the dervish of the dawn archetype from HA to the prerequisites for limitless bardic performance, but the feat does not actually make the ability free even though the resource used is the same. This is also the case with the people's council paladin archetype also added by HA and Ocean's Echo added by Expanded Content. These used to work before commit 1.5.11, before `Resource.Cache.Ability` was changed to `BpCache.Get<BlueprintAbility>()` which I suspect is the culprit. I do not have the development environment necessary to do a proper debug so can't say why.

- Fixes related to limitless alchemist prerequisites.