### PR TITLE
Add a null check to GetEligible

### DIFF
--- a/CodexLib/Components/SpellPerfection.cs
+++ b/CodexLib/Components/SpellPerfection.cs
@@ -57,8 +57,8 @@ namespace CodexLib
                 return null;
             if (bp == spell)
                 return spell;
-            if (bp == spell.Parent)
-                return spell.Parent;
+            if (bp == spell?.Parent)
+                return spell?.Parent;
             return null;
         }
 


### PR DESCRIPTION
spell could be null here, as it's from MechanicsContext.SourceAbility, which could be null, I don't know what cause it to be null, maybe some other mod but when it does, it seriously breaks things, like interupting AI's full attack
Thankee